### PR TITLE
chore: update vega-protos dependencies to the latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
     "@tsconfig/svelte": "^5.0.4",
-    "@vegaprotocol/protos": "^0.14.0",
+    "@vegaprotocol/protos": "^0.16.0",
     "jsonata": "^2.0.4",
     "jsondiffpatch": "^0.6.0",
     "monaco-editor": "^0.48.0",


### PR DESCRIPTION
Update the vega-protos dependency to support the last protobuf schema deployed on mainnet. 

Tested locally and all appears to works fine and support latest proto changes.